### PR TITLE
Fix Robolectric 4.6

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -5,13 +5,13 @@ object Libs {
    const val artifactId = "kotest-extensions-robolectric"
 
    object Kotest {
-      private const val version = "4.4.1"
+      private const val version = "4.6.3"
       const val api = "io.kotest:kotest-framework-api:$version"
       const val junit5 = "io.kotest:kotest-runner-junit5-jvm:$version"
    }
 
    object Robolectric {
-      private const val version = "4.5.1"
+      private const val version = "4.6.1"
       const val robolectric = "org.robolectric:robolectric:$version"
    }
 


### PR DESCRIPTION
fix https://github.com/kotest/kotest-extensions-robolectric/issues/2

# Description
`getConfiguration()` became private

# Problem
`getConfig(method: Method?): Config` is Deprecated too.

There seems to be an alternative, but I couldn't figure out how to use it for me.
```
  /**
   * Compute the effective Robolectric configuration for a given test method.
   *
   * <p>Configuration information is collected from package-level {@code robolectric.properties}
   * files and {@link Config} annotations on test classes, superclasses, and methods.
   *
   * <p>Custom TestRunner subclasses may wish to override this method to provide alternate
   * configuration.
   *
   * @param method the test method
   * @return the effective Robolectric configuration for the given test method
   * @deprecated Provide an implementation of {@link javax.inject.Provider<Config>} instead. This
   *     method will be removed in Robolectric 4.3.
   * @since 2.0
   * @see <a href="http://robolectric.org/migrating/#migrating-to-40">Migration Notes</a> for more
   *     details.
   */
  @Deprecated
  public Config getConfig(Method method) {
    throw new UnsupportedOperationException();
  }
```
Related Issue 
https://github.com/robolectric/robolectric/issues/5656